### PR TITLE
disable update targer methods in WindowTexture

### DIFF
--- a/Assets/uWindowCapture/Scripts/UwcWindowTexture.cs
+++ b/Assets/uWindowCapture/Scripts/UwcWindowTexture.cs
@@ -220,7 +220,8 @@ public class UwcWindowTexture : MonoBehaviour
     void Update()
     {
         UpdateSearchTiming();
-        UpdateTargetWindow();
+		// Don't update the target window here, but rather let CaptureWindow class from medneoVR do it.
+        //UpdateTargetWindow();
 
         if (!isValid) {
             material_.mainTexture = null;


### PR DESCRIPTION
I disabled the UpdateTargetWindow in the original script, to be able to do it inside medneoVR script. 